### PR TITLE
Remove use of std in no_std code.

### DIFF
--- a/src/asynch/http.rs
+++ b/src/asynch/http.rs
@@ -836,7 +836,7 @@ where
         let slice = match self.parse_digits(&mut digits[..]).await? {
             // This is safe because the following call to `from_str_radix` does
             // its own verification on the bytes.
-            Some(s) => unsafe { std::str::from_utf8_unchecked(s) },
+            Some(s) => unsafe { str::from_utf8_unchecked(s) },
             None => return Ok(None),
         };
 


### PR DESCRIPTION
There's a call to a std function, within a section used by `no_std`, which breaks the compilation, when using the `experimental` feature.

https://github.com/ivmarkov/edge-net/blob/563b2d5def10c516c3cee00f15caacfff2f63c52/src/asynch/http.rs#L839

Other calls to `from_utf8_unchecked()` in this file are using `core::str::from_utf8_unchecked()`, which is imported with  
 `use core::str;`