### PR TITLE
Fixes captive.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,15 @@ rust-version = "1.61"
 
 [[example]]
 name="captive_portal"
-required-features = ["std"]
+required-features = ["std", "domain"]
 
 [features]
-default = ["std", "domain"]
+default = ["std"]
 
-std = ["alloc", "embedded-io/std", "embassy-sync/std", "embedded-svc?/std", "async-io", "futures-lite", "httparse/std", "domain/std"]
+std = ["alloc", "embedded-io/std", "embassy-sync/std", "embedded-svc?/std", "async-io", "futures-lite", "httparse/std", "domain?/std"]
 alloc = ["embedded-io/alloc", "embedded-svc?/alloc"]
 nightly = ["embedded-io/async", "embassy-sync/nightly", "embedded-svc?/nightly", "embedded-svc?/experimental"]
 embassy-util = [] # Just for backward compat. To be removed in future
-domain = []
 
 [dependencies]
 embedded-io = { version = "0.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,18 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 rust-version = "1.61"
 
-[features]
-default = ["std"]
+[[example]]
+name="captive_portal"
+required-features = ["std"]
 
-std = ["alloc", "embedded-io/std", "embassy-sync/std", "embedded-svc?/std", "async-io", "futures-lite", "httparse/std", "domain?/std"]
+[features]
+default = ["std", "domain"]
+
+std = ["alloc", "embedded-io/std", "embassy-sync/std", "embedded-svc?/std", "async-io", "futures-lite", "httparse/std", "domain/std"]
 alloc = ["embedded-io/alloc", "embedded-svc?/alloc"]
 nightly = ["embedded-io/async", "embassy-sync/nightly", "embedded-svc?/nightly", "embedded-svc?/experimental"]
 embassy-util = [] # Just for backward compat. To be removed in future
+domain = []
 
 [dependencies]
 embedded-io = { version = "0.3", default-features = false }

--- a/examples/captive_portal.rs
+++ b/examples/captive_portal.rs
@@ -1,0 +1,8 @@
+use edge_net::captive::{DnsConf, DnsServer};
+fn main() {
+    let mut dns_conf = DnsConf::new("192.168.71.1".parse().unwrap());
+    dns_conf.bind_port = 1053;
+    let mut dns_server = DnsServer::new(dns_conf);
+    dns_server.start().unwrap();
+    loop {}
+}


### PR DESCRIPTION
I've added an example for the captive DNS server.
On an esp32c3 the DNS server crashes when trying to receive via UDP socket after moving the socket to a different thread.
If `UDPSocket::bind()` and `socket.recv_from()` are called from the same thread no crash happens.
Additionally about 9000 bytes of stack memory are needed to run the server.