### PR TITLE
DHCP improvements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ members = [
 [workspace.dependencies]
 embassy-futures = { version = "0.1", default-features = false }
 embassy-sync = { version = "0.3", default-features = false }
-embassy-time = { version = "0.1", default-features = false }
+embassy-time = { version = "0.2", default-features = false }
 embedded-io-async = { version = "0.6", default-features = false }
 embedded-nal-async = { version = "0.6", default-features = false }
 embedded-svc = { version = "0.26", default-features = false, features = ["embedded-io-async"] }

--- a/edge-dhcp/src/lib.rs
+++ b/edge-dhcp/src/lib.rs
@@ -3,7 +3,7 @@
 /// This code is a `no_std` and no-alloc modification of https://github.com/krolaw/dhcp4r
 use core::str::Utf8Error;
 
-use no_std_net::Ipv4Addr;
+pub use no_std_net::Ipv4Addr;
 
 use num_enum::TryFromPrimitive;
 

--- a/edge-dhcp/src/lib.rs
+++ b/edge-dhcp/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+use core::fmt;
 /// This code is a `no_std` and no-alloc modification of https://github.com/krolaw/dhcp4r
 use core::str::Utf8Error;
 
@@ -78,6 +79,22 @@ pub enum MessageType {
     /// Client to server, asking only for local configuration parameters; client already has
     /// externally configured network address.
     Inform = 8,
+}
+
+impl fmt::Display for MessageType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Discover => "DHCPDISCOVER",
+            Self::Offer => "DHCPOFFER",
+            Self::Request => "DHCPREQUEST",
+            Self::Decline => "DHCPDECLINE",
+            Self::Ack => "DHCPACK",
+            Self::Nak => "DHCPNAK",
+            Self::Release => "DHCPRELEASE",
+            Self::Inform => "DHCPINFORM",
+        }
+        .fmt(f)
+    }
 }
 
 /// DHCP Packet Structure

--- a/edge-dhcp/src/lib.rs
+++ b/edge-dhcp/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 /// This code is a `no_std` and no-alloc modification of https://github.com/krolaw/dhcp4r
 use core::str::Utf8Error;
 

--- a/edge-dhcp/src/lib.rs
+++ b/edge-dhcp/src/lib.rs
@@ -323,7 +323,7 @@ impl From<&Packet<'_>> for Settings {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Options<'a>(OptionsInner<'a>);
 
 impl<'a> Options<'a> {
@@ -454,6 +454,12 @@ impl<'a> Options<'a> {
 
     pub fn iter(&self) -> impl Iterator<Item = DhcpOption<'a>> + 'a {
         self.0.iter()
+    }
+}
+
+impl fmt::Debug for Options<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 

--- a/edge-dhcp/src/lib.rs
+++ b/edge-dhcp/src/lib.rs
@@ -458,6 +458,16 @@ impl<'a> Options<'a> {
     pub fn iter(&self) -> impl Iterator<Item = DhcpOption<'a>> + 'a {
         self.0.iter()
     }
+
+    pub(crate) fn requested_ip(&self) -> Option<Ipv4Addr> {
+        self.iter().find_map(|option| {
+            if let DhcpOption::RequestedIpAddress(ip) = option {
+                Some(ip)
+            } else {
+                None
+            }
+        })
+    }
 }
 
 impl fmt::Debug for Options<'_> {

--- a/edge-dhcp/src/lib.rs
+++ b/edge-dhcp/src/lib.rs
@@ -149,24 +149,27 @@ impl<'a> Packet<'a> {
         }
     }
 
-    pub fn new_reply<'b>(
-        &self,
-        ciaddr: Option<Ipv4Addr>,
-        yiaddr: Option<Ipv4Addr>,
-        siaddr: Option<Ipv4Addr>,
-        giaddr: Option<Ipv4Addr>,
-        options: Options<'b>,
-    ) -> Packet<'b> {
+    pub fn new_reply<'b>(&self, ip: Option<Ipv4Addr>, options: Options<'b>) -> Packet<'b> {
+        let mut ciaddr = Ipv4Addr::UNSPECIFIED;
+        if ip.is_some() {
+            for opt in self.options.iter() {
+                if matches!(opt, DhcpOption::MessageType(MessageType::Request)) {
+                    ciaddr = self.ciaddr;
+                    break;
+                }
+            }
+        }
+
         Packet {
             reply: true,
             hops: 0,
             xid: self.xid,
             secs: 0,
             broadcast: self.broadcast,
-            ciaddr: ciaddr.unwrap_or(Ipv4Addr::UNSPECIFIED),
-            yiaddr: yiaddr.unwrap_or(Ipv4Addr::UNSPECIFIED),
-            siaddr: siaddr.unwrap_or(Ipv4Addr::UNSPECIFIED),
-            giaddr: giaddr.unwrap_or(Ipv4Addr::UNSPECIFIED),
+            ciaddr,
+            yiaddr: ip.unwrap_or(Ipv4Addr::UNSPECIFIED),
+            siaddr: Ipv4Addr::UNSPECIFIED,
+            giaddr: self.giaddr,
             chaddr: self.chaddr,
             options,
         }

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -113,11 +113,16 @@ impl<'a> ServerOptions<'a> {
         ip: Option<Ipv4Addr>,
         opt_buf: &'a mut [DhcpOption<'a>],
     ) -> Packet<'a> {
-        if let Some(ip) = ip {
-            self.reply(request, MessageType::Ack, Some(ip), opt_buf)
-        } else {
-            self.reply(request, MessageType::Nak, None, opt_buf)
-        }
+        self.reply(
+            request,
+            if ip.is_some() {
+                MessageType::Ack
+            } else {
+                MessageType::Nak
+            },
+            ip,
+            opt_buf,
+        )
     }
 
     fn reply(

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -101,7 +101,7 @@ impl<'a> ServerOptions<'a> {
         yiaddr: Ipv4Addr,
         opt_buf: &'a mut [DhcpOption<'a>],
     ) -> Packet<'a> {
-        self.reply(
+        let reply = self.reply(
             request,
             MessageType::Offer,
             None,
@@ -109,7 +109,11 @@ impl<'a> ServerOptions<'a> {
             None,
             Some(request.giaddr),
             opt_buf,
-        )
+        );
+
+        info!("DHCPOFFER {reply:?}");
+
+        reply
     }
 
     pub fn ack_nak(
@@ -133,7 +137,7 @@ impl<'a> ServerOptions<'a> {
     ) -> Packet<'a> {
         let siaddr = None;
 
-        self.reply(
+        let reply = self.reply(
             request,
             message_type,
             Some(request.ciaddr),
@@ -141,11 +145,15 @@ impl<'a> ServerOptions<'a> {
             None, // Could also be this server's IP address.
             Some(request.giaddr),
             opt_buf,
-        )
+        );
+
+        info!("DHCPACK {reply:?}");
+
+        reply
     }
 
     fn nak(&self, request: &Packet, opt_buf: &'a mut [DhcpOption<'a>]) -> Packet<'a> {
-        self.reply(
+        let reply = self.reply(
             request,
             message_type,
             None,
@@ -153,7 +161,11 @@ impl<'a> ServerOptions<'a> {
             None,
             Some(request.giaddr),
             opt_buf,
-        )
+        );
+
+        info!("DHCPNAK {reply:?}");
+
+        reply
     }
 
     fn reply(
@@ -166,7 +178,7 @@ impl<'a> ServerOptions<'a> {
         giaddr: Option<Ipv4Addr>,
         buf: &'a mut [DhcpOption<'a>],
     ) -> Packet<'a> {
-        let reply = request.new_reply(
+        request.new_reply(
             ciaddr,
             yiaddr,
             siaddr,
@@ -180,11 +192,7 @@ impl<'a> ServerOptions<'a> {
                 self.dns,
                 buf,
             ),
-        );
-
-        info!("Reply: {reply:?}");
-
-        reply
+        )
     }
 }
 

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -68,10 +68,17 @@ impl<'a> ServerOptions<'a> {
                 request.options.requested_ip(),
                 &request.chaddr,
             )),
-            MessageType::Request => Some(Action::Request(
-                request.options.requested_ip()?,
-                &request.chaddr,
-            )),
+            MessageType::Request => {
+                let requested_ip = request.options.requested_ip().or_else(|| {
+                    if request.ciaddr.is_unspecified() {
+                        None
+                    } else {
+                        Some(request.ciaddr)
+                    }
+                })?;
+
+                Some(Action::Request(requested_ip, &request.chaddr))
+            }
             MessageType::Release if server_identifier == Some(self.ip) => {
                 Some(Action::Release(request.yiaddr, &request.chaddr))
             }

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -139,7 +139,7 @@ impl<'a> ServerOptions<'a> {
 
         let reply = self.reply(
             request,
-            message_type,
+            MessageType::Ack,
             Some(request.ciaddr),
             Some(yiaddr),
             None, // Could also be this server's IP address.
@@ -155,7 +155,7 @@ impl<'a> ServerOptions<'a> {
     fn nak(&self, request: &Packet, opt_buf: &'a mut [DhcpOption<'a>]) -> Packet<'a> {
         let reply = self.reply(
             request,
-            message_type,
+            MessageType::Nak,
             None,
             None,
             None,

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -89,6 +89,8 @@ impl<'a> ServerOptions<'a> {
                 };
 
                 return request;
+            } else {
+                info!("Ignoring {message_type} request: {request:?}");
             }
         }
 

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -109,7 +109,7 @@ impl<'a> ServerOptions<'a> {
             MessageType::Offer,
             None,
             Some(yiaddr),
-            None,
+            Some(self.ip),
             Some(request.giaddr),
             opt_buf,
         )
@@ -139,7 +139,7 @@ impl<'a> ServerOptions<'a> {
             MessageType::Ack,
             Some(request.ciaddr),
             Some(yiaddr),
-            None, // Could also be this server's IP address.
+            Some(self.ip),
             Some(request.giaddr),
             opt_buf,
         )

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -101,7 +101,15 @@ impl<'a> ServerOptions<'a> {
         ip: Ipv4Addr,
         opt_buf: &'a mut [DhcpOption<'a>],
     ) -> Packet<'a> {
-        self.reply(request, MessageType::Offer, Some(ip), opt_buf)
+        self.reply(
+            request,
+            MessageType::Offer,
+            None,
+            Some(ip),
+            Some(request.siaddr),
+            Some(request.giaddr),
+            opt_buf,
+        )
     }
 
     pub fn ack_nack(
@@ -118,6 +126,9 @@ impl<'a> ServerOptions<'a> {
                 MessageType::Nak
             },
             ip,
+            ip,
+            Some(request.siaddr),
+            Some(request.giaddr),
             opt_buf,
         )
     }
@@ -126,11 +137,17 @@ impl<'a> ServerOptions<'a> {
         &self,
         request: &Packet,
         mt: MessageType,
-        ip: Option<Ipv4Addr>,
+        ciaddr: Option<Ipv4Addr>,
+        yiaddr: Option<Ipv4Addr>,
+        siaddr: Option<Ipv4Addr>,
+        giaddr: Option<Ipv4Addr>,
         buf: &'a mut [DhcpOption<'a>],
     ) -> Packet<'a> {
         let reply = request.new_reply(
-            ip,
+            ciaddr,
+            yiaddr,
+            siaddr,
+            giaddr,
             request.options.reply(
                 mt,
                 self.ip,

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -104,74 +104,31 @@ impl<'a> ServerOptions<'a> {
         yiaddr: Ipv4Addr,
         opt_buf: &'a mut [DhcpOption<'a>],
     ) -> Packet<'a> {
-        self.reply(
-            request,
-            MessageType::Offer,
-            None,
-            Some(yiaddr),
-            Some(self.ip),
-            Some(request.giaddr),
-            opt_buf,
-        )
+        self.reply(request, MessageType::Offer, Some(yiaddr), opt_buf)
     }
 
     pub fn ack_nak(
         &self,
         request: &Packet,
-        yiaddr: Option<Ipv4Addr>,
+        ip: Option<Ipv4Addr>,
         opt_buf: &'a mut [DhcpOption<'a>],
     ) -> Packet<'a> {
-        if let Some(yiaddr) = yiaddr {
-            self.ack(request, yiaddr, opt_buf)
+        if let Some(ip) = ip {
+            self.reply(request, MessageType::Ack, Some(ip), opt_buf)
         } else {
-            self.nak(request, opt_buf)
+            self.reply(request, MessageType::Nak, None, opt_buf)
         }
-    }
-
-    fn ack(
-        &self,
-        request: &Packet,
-        yiaddr: Ipv4Addr,
-        opt_buf: &'a mut [DhcpOption<'a>],
-    ) -> Packet<'a> {
-        self.reply(
-            request,
-            MessageType::Ack,
-            Some(request.ciaddr),
-            Some(yiaddr),
-            Some(self.ip),
-            Some(request.giaddr),
-            opt_buf,
-        )
-    }
-
-    fn nak(&self, request: &Packet, opt_buf: &'a mut [DhcpOption<'a>]) -> Packet<'a> {
-        self.reply(
-            request,
-            MessageType::Nak,
-            None,
-            None,
-            None,
-            Some(request.giaddr),
-            opt_buf,
-        )
     }
 
     fn reply(
         &self,
         request: &Packet,
         message_type: MessageType,
-        ciaddr: Option<Ipv4Addr>,
-        yiaddr: Option<Ipv4Addr>,
-        siaddr: Option<Ipv4Addr>,
-        giaddr: Option<Ipv4Addr>,
+        ip: Option<Ipv4Addr>,
         buf: &'a mut [DhcpOption<'a>],
     ) -> Packet<'a> {
         let reply = request.new_reply(
-            ciaddr,
-            yiaddr,
-            siaddr,
-            giaddr,
+            ip,
             request.options.reply(
                 message_type,
                 self.ip,

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -135,8 +135,6 @@ impl<'a> ServerOptions<'a> {
         yiaddr: Ipv4Addr,
         opt_buf: &'a mut [DhcpOption<'a>],
     ) -> Packet<'a> {
-        let siaddr = None;
-
         let reply = self.reply(
             request,
             MessageType::Ack,

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use embassy_time::{Duration, Instant};
 
-use log::info;
+use log::{info, warn};
 
 use super::*;
 
@@ -45,7 +45,7 @@ impl<'a> ServerOptions<'a> {
         let message_type = if let Some(message_type) = message_type {
             message_type
         } else {
-            info!("Ignoring DHCP request, no message type found: {request:?}");
+            warn!("Ignoring DHCP request, no message type found: {request:?}");
             return None;
         };
 
@@ -58,7 +58,7 @@ impl<'a> ServerOptions<'a> {
         });
 
         if server_identifier.is_some() && server_identifier != Some(self.ip) {
-            info!("Ignoring {message_type} request, not addressed to this server: {request:?}");
+            warn!("Ignoring {message_type} request, not addressed to this server: {request:?}");
             return None;
         }
 


### PR DESCRIPTION
Some small improvements to get this working in the `esp-wifi/embassy_access_point` example. 

I guess some changes are not technically necessary to get it working, since I now figured out that the `DHCPOFFER` response needs to be sent as a broadcast, at least if the client IP is `0.0.0.0`.
