### PR TITLE
DNS improvements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ members = [
     "edge-dhcp",
     "edge-http",
     "edge-mdns",
-    "edge-mqtt", 
+    "edge-mqtt",
     "edge-raw",
     "edge-ws",
     "edge-std-nal-async",

--- a/edge-captive/Cargo.toml
+++ b/edge-captive/Cargo.toml
@@ -8,5 +8,5 @@ std = ["domain/std"]
 
 [dependencies]
 log = { workspace = true }
-domain = { version = "0.9.3-dev", default-features = false, features = ["heapless"] }
+domain = { version = "0.9.3", default-features = false, features = ["heapless"] }
 heapless = { workspace = true }

--- a/edge-captive/Cargo.toml
+++ b/edge-captive/Cargo.toml
@@ -8,4 +8,5 @@ std = ["domain/std"]
 
 [dependencies]
 log = { workspace = true }
-domain = { version = "0.7", default-features = false }
+domain = { version = "0.9.3-dev", default-features = false, features = ["heapless"] }
+heapless = { workspace = true }


### PR DESCRIPTION
Note that currently these patches 

```toml
domain = { git = "https://github.com/reitermarkus/domain", branch = "no-std" }
octseq = { git = "https://github.com/reitermarkus/octseq" }
```

are needed until 

https://github.com/NLnetLabs/octseq/pull/45 and https://github.com/NLnetLabs/domain/pull/248 are merged.
