### PR TITLE
docs: Document safety about socket count for embassy

### DIFF
--- a/edge-nal-embassy/src/tcp.rs
+++ b/edge-nal-embassy/src/tcp.rs
@@ -23,6 +23,10 @@ impl<'d, D: Driver, const N: usize, const TX_SZ: usize, const RX_SZ: usize>
     Tcp<'d, D, N, TX_SZ, RX_SZ>
 {
     /// Create a new `Tcp` instance for the provided Embassy networking stack, using the provided TCP buffers
+    ///
+    /// Ensure that the number of buffers `N` fits within StackResources<N> of
+    /// [embassy_net::Stack], while taking into account the sockets used for DHCP, DNS, etc. else
+    /// [smoltcp::iface::SocketSet] will panic with `adding a socket to a full SocketSet`.
     pub fn new(stack: &'d Stack<D>, buffers: &'d TcpBuffers<N, TX_SZ, RX_SZ>) -> Self {
         Self { stack, buffers }
     }


### PR DESCRIPTION
I ran into an edge case where I didn't supply enough sockets to use the server for `edge-http` with `embassy-net` and `esp-wifi`, and smoltcp would panic with `adding a socket to a full SocketSet`.

This document the behavior so that users are aware to provide enough sockets, taking into account the sockets used for DHCP, DNS, etc. when initializing their `StackResources<N>`