### PR TITLE
Update futures-lite to match version in async-io-mini

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ embassy-time = { version = "0.3", features = ["std", "generic-queue"] }
 embassy-sync = "0.6"
 embassy-futures = "0.1"
 embedded-svc = { version = "0.28", features = ["std"] }
-futures-lite = "1"
+futures-lite = "2"
 rand = "0.8"
 tokio = "1" # For the `mqtt_client` example
 async-compat = "0.2" # For the `mqtt_client` example

--- a/edge-nal-std/Cargo.toml
+++ b/edge-nal-std/Cargo.toml
@@ -19,6 +19,6 @@ embedded-io-async = { workspace = true, features = ["std"] }
 edge-nal = { workspace = true }
 async-io = "2"
 async-io-mini = { git = "https://github.com/ivmarkov/async-io-mini", optional = true }
-futures-lite = "1"
+futures-lite = "2"
 libc = "0.2"
 heapless = { workspace = true }


### PR DESCRIPTION
Upgrades `futures-lite` to match the [PR](https://github.com/ivmarkov/async-io-mini/pull/5) for `async-io-mini`.

## Open Questions

- [ ] This is a breaking API change. Therefore, at least `edge-net` would need to be updated to `0.8.0` and `edge-nal-std` to `0.3.0`. However, the latter would then be inconsistent with the versions of the remaining crates.