### PR TITLE
Reduce logging level for captive portal and DHCP server

### DIFF
--- a/edge-captive/src/lib.rs
+++ b/edge-captive/src/lib.rs
@@ -88,20 +88,13 @@ pub fn reply(
             let question = question?;
 
             if matches!(question.qtype(), Rtype::A) && matches!(question.qclass(), Class::IN) {
-                log::info!(
-                    "Question {:?} is of type A, answering with IP {:?}, TTL {:?}",
-                    question,
-                    ip,
-                    ttl
-                );
-
                 let record = Record::new(
                     question.qname(),
                     Class::IN,
                     Ttl::from_duration_lossy(ttl),
                     A::from_octets(ip[0], ip[1], ip[2], ip[3]),
                 );
-                debug!("Answering question {:?} with {:?}", question, record);
+                debug!("Answering {:?} with {:?}", question, record);
                 answerb.push(record)?;
             } else {
                 debug!("Question {:?} is not of type A, not answering", question);

--- a/edge-dhcp/src/server.rs
+++ b/edge-dhcp/src/server.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use embassy_time::{Duration, Instant};
 
-use log::{info, warn};
+use log::{debug, warn};
 
 use super::*;
 
@@ -80,7 +80,7 @@ impl<'a> ServerOptions<'a> {
             return None;
         }
 
-        info!("Received {message_type} request: {request:?}");
+        debug!("Received {message_type} request: {request:?}");
         match message_type {
             MessageType::Discover => Some(Action::Discover(
                 request.options.requested_ip(),
@@ -154,7 +154,7 @@ impl<'a> ServerOptions<'a> {
             ),
         );
 
-        info!("Sending {message_type} reply: {reply:?}");
+        debug!("Sending {message_type} reply: {reply:?}");
 
         reply
     }


### PR DESCRIPTION
This reduce the logging level for DHCP requests / responses when running as a server from info to debug.
I've also updated the logging for DNS requests in `edge-captive` to remove the word `"question"` that would be printed twice due to the name of the struct being included, and also removed a similar logging line with level info. 