### PR TITLE
Always send a SP after status code, even if no reason is given

### DIFF
--- a/edge-http/src/io.rs
+++ b/edge-http/src/io.rs
@@ -1211,11 +1211,10 @@ mod raw {
             written = true;
         }
 
+        if written {
+            output.write_all(b" ").await.map_err(Error::Io)?;
+        }
         if let Some(extra) = extra {
-            if written {
-                output.write_all(b" ").await.map_err(Error::Io)?;
-            }
-
             output
                 .write_all(extra.as_bytes())
                 .await


### PR DESCRIPTION
In [section 4 of RFC 9112](https://www.rfc-editor.org/rfc/rfc9112#section-4), we can see that the status line should adhere to this format:

```
  status-line = HTTP-version SP status-code SP [ reason-phrase ]
```

Even if no `reason-phrase` is given, there should still be a SP (space) after `status-code`. `edge-http` does not have this second SP, if reason is empty.

Example (`|` marks begin and end of line):

Valid status line: `|HTTP/1.1 101 |`
Wrong status line (which is the current behavior): `|HTTP/1.1 101|`

This is causing trouble for the python [websockets](https://github.com/python-websockets/websockets) library, because it want two `SP`s in the status line (which is valid according to the spec). [See code here](https://github.com/python-websockets/websockets/blob/7fdd932c6b29a9ef4db46b2141371f42207b4f00/src/websockets/http11.py#L241)

This can be reproduced by running the `ws_server` example on Linux machine, and running `python3 -m websockets ws://<ip>:8881`:

```
Failed to connect to ws://<ip>:8881: invalid HTTP status line: HTTP/1.1 101.
```
