### PR TITLE
edge-http: make fields in {Req,Resp}Headers non-optional

### DIFF
--- a/edge-http/src/io.rs
+++ b/edge-http/src/io.rs
@@ -100,11 +100,10 @@ impl<E> std::error::Error for Error<E> where E: std::error::Error {}
 impl<'b, const N: usize> RequestHeaders<'b, N> {
     /// Parse the headers from the input stream
     pub async fn receive<R>(
-        &mut self,
         buf: &'b mut [u8],
         mut input: R,
         exact: bool,
-    ) -> Result<(&'b mut [u8], usize), Error<R::Error>>
+    ) -> Result<(Self, &'b mut [u8], usize), Error<R::Error>>
     where
         R: Read,
     {
@@ -114,7 +113,8 @@ impl<'b, const N: usize> RequestHeaders<'b, N> {
                 Err(e) => return Err(e),
             };
 
-        let mut parser = httparse::Request::new(&mut self.headers.0);
+        let mut headers = Headers::<'b, N>::new();
+        let mut parser = httparse::Request::new(&mut headers.0);
 
         let (headers_buf, body_buf) = buf.split_at_mut(headers_len);
 
@@ -128,22 +128,26 @@ impl<'b, const N: usize> RequestHeaders<'b, N> {
                 unreachable!("Should not happen. HTTP header parsing is indeterminate.")
             }
 
-            self.http11 = if let Some(version) = parser.version {
-                if version > 1 {
-                    Err(Error::InvalidHeaders)?;
-                }
-
-                Some(version == 1)
-            } else {
-                None
+            let http11 = match parser.version {
+                Some(0) => false,
+                Some(1) => true,
+                _ => Err(Error::InvalidHeaders)?,
             };
 
-            self.method = parser.method.and_then(Method::new);
-            self.path = parser.path;
+            let method_str = parser.method.ok_or(Error::InvalidHeaders)?;
+            let method = Method::new(method_str).ok_or(Error::InvalidHeaders)?;
+            let path = parser.path.ok_or(Error::InvalidHeaders)?;
 
-            trace!("Received:\n{}", self);
+            let result = Self {
+                http11,
+                method,
+                path,
+                headers,
+            };
 
-            Ok((body_buf, read_len - headers_len))
+            trace!("Received:\n{}", result);
+
+            Ok((result, body_buf, read_len - headers_len))
         } else {
             unreachable!("Secondary parse of already loaded buffer failed.")
         }
@@ -151,8 +155,7 @@ impl<'b, const N: usize> RequestHeaders<'b, N> {
 
     /// Resolve the connection type and body type from the headers
     pub fn resolve<E>(&self) -> Result<(ConnectionType, BodyType), Error<E>> {
-        self.headers
-            .resolve::<E>(None, true, self.http11.unwrap_or(false))
+        self.headers.resolve::<E>(None, true, self.http11)
     }
 
     /// Send the headers to the output stream, returning the connection type and body type
@@ -164,12 +167,10 @@ impl<'b, const N: usize> RequestHeaders<'b, N> {
     where
         W: Write,
     {
-        let http11 = self.http11.unwrap_or(false);
-
-        send_request(http11, self.method, self.path, &mut output).await?;
+        send_request(self.http11, self.method, self.path, &mut output).await?;
 
         self.headers
-            .send(None, true, http11, chunked_if_unspecified, output)
+            .send(None, true, self.http11, chunked_if_unspecified, output)
             .await
     }
 }
@@ -177,18 +178,18 @@ impl<'b, const N: usize> RequestHeaders<'b, N> {
 impl<'b, const N: usize> ResponseHeaders<'b, N> {
     /// Parse the headers from the input stream
     pub async fn receive<R>(
-        &mut self,
         buf: &'b mut [u8],
         mut input: R,
         exact: bool,
-    ) -> Result<(&'b mut [u8], usize), Error<R::Error>>
+    ) -> Result<(Self, &'b mut [u8], usize), Error<R::Error>>
     where
         R: Read,
     {
         let (read_len, headers_len) =
             raw::read_reply_buf::<N, _>(&mut input, buf, false, exact).await?;
 
-        let mut parser = httparse::Response::new(&mut self.headers.0);
+        let mut headers = Headers::<'b, N>::new();
+        let mut parser = httparse::Response::new(&mut headers.0);
 
         let (headers_buf, body_buf) = buf.split_at_mut(headers_len);
 
@@ -199,22 +200,25 @@ impl<'b, const N: usize> ResponseHeaders<'b, N> {
                 unreachable!("Should not happen. HTTP header parsing is indeterminate.")
             }
 
-            self.http11 = if let Some(version) = parser.version {
-                if version > 1 {
-                    Err(Error::InvalidHeaders)?;
-                }
-
-                Some(version == 1)
-            } else {
-                None
+            let http11 = match parser.version {
+                Some(0) => false,
+                Some(1) => true,
+                _ => Err(Error::InvalidHeaders)?,
             };
 
-            self.code = parser.code;
-            self.reason = parser.reason;
+            let code = parser.code.ok_or(Error::InvalidHeaders)?;
+            let reason = parser.reason;
 
-            trace!("Received:\n{}", self);
+            let result = Self {
+                http11,
+                code,
+                reason,
+                headers,
+            };
 
-            Ok((body_buf, read_len - headers_len))
+            trace!("Received:\n{}", result);
+
+            Ok((result, body_buf, read_len - headers_len))
         } else {
             unreachable!("Secondary parse of already loaded buffer failed.")
         }
@@ -225,11 +229,8 @@ impl<'b, const N: usize> ResponseHeaders<'b, N> {
         &self,
         request_connection_type: ConnectionType,
     ) -> Result<(ConnectionType, BodyType), Error<E>> {
-        self.headers.resolve::<E>(
-            Some(request_connection_type),
-            false,
-            self.http11.unwrap_or(false),
-        )
+        self.headers
+            .resolve::<E>(Some(request_connection_type), false, self.http11)
     }
 
     /// Send the headers to the output stream, returning the connection type and body type
@@ -242,15 +243,13 @@ impl<'b, const N: usize> ResponseHeaders<'b, N> {
     where
         W: Write,
     {
-        let http11 = self.http11.unwrap_or(false);
-
-        send_status(http11, self.code, self.reason, &mut output).await?;
+        send_status(self.http11, self.code, self.reason, &mut output).await?;
 
         self.headers
             .send(
                 Some(request_connection_type),
                 false,
-                http11,
+                self.http11,
                 chunked_if_unspecified,
                 output,
             )
@@ -260,42 +259,56 @@ impl<'b, const N: usize> ResponseHeaders<'b, N> {
 
 pub(crate) async fn send_request<W>(
     http11: bool,
-    method: Option<Method>,
-    path: Option<&str>,
-    output: W,
+    method: Method,
+    path: &str,
+    mut output: W,
 ) -> Result<(), Error<W::Error>>
 where
     W: Write,
 {
-    raw::send_status_line(
-        true,
-        http11,
-        method.map(|method| method.as_str()),
-        path,
-        output,
-    )
-    .await
+    // RFC 9112:   request-line   = method SP request-target SP HTTP-version
+
+    output
+        .write_all(method.as_str().as_bytes())
+        .await
+        .map_err(Error::Io)?;
+    output.write_all(b" ").await.map_err(Error::Io)?;
+    output.write_all(path.as_bytes()).await.map_err(Error::Io)?;
+    output.write_all(b" ").await.map_err(Error::Io)?;
+    raw::send_version(&mut output, http11).await?;
+    output.write_all(b"\r\n").await.map_err(Error::Io)?;
+
+    Ok(())
 }
 
 pub(crate) async fn send_status<W>(
     http11: bool,
-    status: Option<u16>,
+    status: u16,
     reason: Option<&str>,
-    output: W,
+    mut output: W,
 ) -> Result<(), Error<W::Error>>
 where
     W: Write,
 {
-    let status_str: Option<heapless::String<5>> = status.map(|status| status.try_into().unwrap());
+    // RFC 9112:   status-line = HTTP-version SP status-code SP [ reason-phrase ]
 
-    raw::send_status_line(
-        false,
-        http11,
-        status_str.as_ref().map(|status| status.as_str()),
-        reason,
-        output,
-    )
-    .await
+    raw::send_version(&mut output, http11).await?;
+    output.write_all(b" ").await.map_err(Error::Io)?;
+    let status_str: heapless::String<5> = status.try_into().unwrap();
+    output
+        .write_all(status_str.as_bytes())
+        .await
+        .map_err(Error::Io)?;
+    output.write_all(b" ").await.map_err(Error::Io)?;
+    if let Some(reason) = reason {
+        output
+            .write_all(reason.as_bytes())
+            .await
+            .map_err(Error::Io)?;
+    }
+    output.write_all(b"\r\n").await.map_err(Error::Io)?;
+
+    Ok(())
 }
 
 pub(crate) async fn send_headers<'a, H, W>(
@@ -1179,61 +1192,6 @@ mod raw {
                 break Ok(offset);
             }
         }
-    }
-
-    pub(crate) async fn send_status_line<W>(
-        request: bool,
-        http11: bool,
-        token: Option<&str>,
-        extra: Option<&str>,
-        mut output: W,
-    ) -> Result<(), Error<W::Error>>
-    where
-        W: Write,
-    {
-        let mut written = false;
-
-        if !request {
-            send_version(&mut output, http11).await?;
-            written = true;
-        }
-
-        if let Some(token) = token {
-            if written {
-                output.write_all(b" ").await.map_err(Error::Io)?;
-            }
-
-            output
-                .write_all(token.as_bytes())
-                .await
-                .map_err(Error::Io)?;
-
-            written = true;
-        }
-
-        if written {
-            output.write_all(b" ").await.map_err(Error::Io)?;
-        }
-        if let Some(extra) = extra {
-            output
-                .write_all(extra.as_bytes())
-                .await
-                .map_err(Error::Io)?;
-
-            written = true;
-        }
-
-        if request {
-            if written {
-                output.write_all(b" ").await.map_err(Error::Io)?;
-            }
-
-            send_version(&mut output, http11).await?;
-        }
-
-        output.write_all(b"\r\n").await.map_err(Error::Io)?;
-
-        Ok(())
     }
 
     pub(crate) async fn send_version<W>(mut output: W, http11: bool) -> Result<(), Error<W::Error>>

--- a/edge-http/src/io/client.rs
+++ b/edge-http/src/io/client.rs
@@ -262,9 +262,13 @@ where
 
         let mut state = self.unbind();
         let buf_ptr: *mut [u8] = state.buf;
+        let mut response = ResponseHeaders::default();
 
-        match ResponseHeaders::receive(state.buf, &mut state.io.as_mut().unwrap(), true).await {
-            Ok((response, buf, read_len)) => {
+        match response
+            .receive(state.buf, &mut state.io.as_mut().unwrap(), true)
+            .await
+        {
+            Ok((buf, read_len)) => {
                 let (connection_type, body_type) =
                     response.resolve::<T::Error>(request_connection_type)?;
 

--- a/edge-http/src/io/client.rs
+++ b/edge-http/src/io/client.rs
@@ -262,7 +262,7 @@ where
 
         let mut state = self.unbind();
         let buf_ptr: *mut [u8] = state.buf;
-        let mut response = ResponseHeaders::default();
+        let mut response = ResponseHeaders::new();
 
         match response
             .receive(state.buf, &mut state.io.as_mut().unwrap(), true)

--- a/edge-http/src/io/client.rs
+++ b/edge-http/src/io/client.rs
@@ -174,7 +174,7 @@ where
         let mut state = self.unbind();
 
         let result = async {
-            match send_request(http11, Some(method), Some(uri), state.io.as_mut().unwrap()).await {
+            match send_request(http11, method, uri, state.io.as_mut().unwrap()).await {
                 Ok(_) => (),
                 Err(Error::Io(_)) => {
                     if !fresh_connection {
@@ -182,8 +182,7 @@ where
                         state.io = None;
                         state.io = Some(state.socket.connect(state.addr).await.map_err(Error::Io)?);
 
-                        send_request(http11, Some(method), Some(uri), state.io.as_mut().unwrap())
-                            .await?;
+                        send_request(http11, method, uri, state.io.as_mut().unwrap()).await?;
                     }
                 }
                 Err(other) => Err(other)?,
@@ -264,13 +263,8 @@ where
         let mut state = self.unbind();
         let buf_ptr: *mut [u8] = state.buf;
 
-        let mut response = ResponseHeaders::new();
-
-        match response
-            .receive(state.buf, &mut state.io.as_mut().unwrap(), true)
-            .await
-        {
-            Ok((buf, read_len)) => {
+        match ResponseHeaders::receive(state.buf, &mut state.io.as_mut().unwrap(), true).await {
+            Ok((response, buf, read_len)) => {
                 let (connection_type, body_type) =
                     response.resolve::<T::Error>(request_connection_type)?;
 

--- a/edge-http/src/io/server.rs
+++ b/edge-http/src/io/server.rs
@@ -52,7 +52,9 @@ where
         buf: &'b mut [u8],
         mut io: T,
     ) -> Result<Connection<'b, T, N>, Error<T::Error>> {
-        let (request, buf, read_len) = RequestHeaders::receive(buf, &mut io, true).await?;
+        let mut request = RequestHeaders::default();
+
+        let (buf, read_len) = request.receive(buf, &mut io, true).await?;
 
         let (connection_type, body_type) = request.resolve::<T::Error>()?;
 

--- a/edge-http/src/io/server.rs
+++ b/edge-http/src/io/server.rs
@@ -52,7 +52,7 @@ where
         buf: &'b mut [u8],
         mut io: T,
     ) -> Result<Connection<'b, T, N>, Error<T::Error>> {
-        let mut request = RequestHeaders::default();
+        let mut request = RequestHeaders::new();
 
         let (buf, read_len) = request.receive(buf, &mut io, true).await?;
 

--- a/edge-http/src/lib.rs
+++ b/edge-http/src/lib.rs
@@ -724,6 +724,7 @@ impl<const N: usize> RequestHeaders<'_, N> {
 }
 
 impl<'b, const N: usize> Default for RequestHeaders<'b, N> {
+    #[inline(always)]
     fn default() -> Self {
         Self {
             http11: true,
@@ -778,6 +779,7 @@ impl<const N: usize> ResponseHeaders<'_, N> {
 }
 
 impl<'b, const N: usize> Default for ResponseHeaders<'b, N> {
+    #[inline(always)]
     fn default() -> Self {
         Self {
             http11: true,

--- a/edge-http/src/lib.rs
+++ b/edge-http/src/lib.rs
@@ -723,6 +723,17 @@ impl<const N: usize> RequestHeaders<'_, N> {
     }
 }
 
+impl<'b, const N: usize> Default for RequestHeaders<'b, N> {
+    fn default() -> Self {
+        Self {
+            http11: true,
+            method: Method::Get,
+            path: "/",
+            headers: Headers::new(),
+        }
+    }
+}
+
 impl<const N: usize> Display for RequestHeaders<'_, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} ", if self.http11 { "HTTP/1.1" } else { "HTTP/1.0" })?;
@@ -763,6 +774,17 @@ impl<const N: usize> ResponseHeaders<'_, N> {
         buf: &mut [u8; MAX_BASE64_KEY_RESPONSE_LEN],
     ) -> bool {
         is_upgrade_accepted(self.code, self.headers.iter(), nonce, buf)
+    }
+}
+
+impl<'b, const N: usize> Default for ResponseHeaders<'b, N> {
+    fn default() -> Self {
+        Self {
+            http11: true,
+            code: 200,
+            reason: None,
+            headers: Headers::new(),
+        }
     }
 }
 

--- a/edge-http/src/lib.rs
+++ b/edge-http/src/lib.rs
@@ -717,6 +717,17 @@ pub struct RequestHeaders<'b, const N: usize> {
 }
 
 impl<const N: usize> RequestHeaders<'_, N> {
+    // Create a new RequestHeaders instance, defaults to GET / HTTP/1.1
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            http11: true,
+            method: Method::Get,
+            path: "/",
+            headers: Headers::new(),
+        }
+    }
+
     /// A utility method to check if the request is a Websocket upgrade request
     pub fn is_ws_upgrade_request(&self) -> bool {
         is_upgrade_request(self.method, self.headers.iter())
@@ -726,12 +737,7 @@ impl<const N: usize> RequestHeaders<'_, N> {
 impl<'b, const N: usize> Default for RequestHeaders<'b, N> {
     #[inline(always)]
     fn default() -> Self {
-        Self {
-            http11: true,
-            method: Method::Get,
-            path: "/",
-            headers: Headers::new(),
-        }
+        Self::new()
     }
 }
 
@@ -767,6 +773,17 @@ pub struct ResponseHeaders<'b, const N: usize> {
 }
 
 impl<const N: usize> ResponseHeaders<'_, N> {
+    /// Create a new ResponseHeaders instance, defaults to HTTP/1.1 200 OK
+    #[inline(always)]
+    pub const fn new() -> Self {
+        Self {
+            http11: true,
+            code: 200,
+            reason: None,
+            headers: Headers::new(),
+        }
+    }
+
     /// A utility method to check if the response is a Websocket upgrade response
     /// and if the upgrade was accepted
     pub fn is_ws_upgrade_accepted(
@@ -781,12 +798,7 @@ impl<const N: usize> ResponseHeaders<'_, N> {
 impl<'b, const N: usize> Default for ResponseHeaders<'b, N> {
     #[inline(always)]
     fn default() -> Self {
-        Self {
-            http11: true,
-            code: 200,
-            reason: None,
-            headers: Headers::new(),
-        }
+        Self::new()
     }
 }
 

--- a/edge-http/src/lib.rs
+++ b/edge-http/src/lib.rs
@@ -833,7 +833,7 @@ pub mod ws {
     where
         H: IntoIterator<Item = (&'a str, &'a str)>,
     {
-        if method == Method::Get {
+        if method != Method::Get {
             return false;
         }
 

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -42,10 +42,10 @@ where
     async fn handle(&self, conn: &mut Connection<'b, T, N>) -> Result<(), Self::Error> {
         let headers = conn.headers()?;
 
-        if !matches!(headers.method, Some(Method::Get)) {
+        if headers.method != Method::Get {
             conn.initiate_response(405, Some("Method Not Allowed"), &[])
                 .await?;
-        } else if !matches!(headers.path, Some("/")) {
+        } else if headers.path != "/" {
             conn.initiate_response(404, Some("Not Found"), &[]).await?;
         } else {
             conn.initiate_response(200, Some("OK"), &[("Content-Type", "text/plain")])

--- a/examples/ws_server.rs
+++ b/examples/ws_server.rs
@@ -58,10 +58,10 @@ where
     async fn handle(&self, conn: &mut Connection<'b, T, N>) -> Result<(), Self::Error> {
         let headers = conn.headers()?;
 
-        if !matches!(headers.method, Some(Method::Get)) {
+        if headers.method != Method::Get {
             conn.initiate_response(405, Some("Method Not Allowed"), &[])
                 .await?;
-        } else if !matches!(headers.path, Some("/")) {
+        } else if headers.path != "/" {
             conn.initiate_response(404, Some("Not Found"), &[]).await?;
         } else if !conn.is_ws_upgrade_request()? {
             conn.initiate_response(200, Some("OK"), &[("Content-Type", "text/plain")])


### PR DESCRIPTION
Ensures that the {Req,Resp}Headers is always complete and adheres to the HTTP spec. Saves a lot code from dealing with `Option`s.

Also, `send_status_line` is removed, and inlined into `send_request` and `send_status`. This cuts ~80 lines from the code, which is nice.