### PR TITLE
Add feature gate for embassy-time for edge-dhcp

### DIFF
--- a/edge-dhcp/Cargo.toml
+++ b/edge-dhcp/Cargo.toml
@@ -15,10 +15,10 @@ categories = [
 ]
 
 [features]
-default = ["io"]
-std = ["io"]
+default = ["io", "std"]
 io = ["embassy-futures", "edge-nal", "time"]
 time = ["embassy-time"]
+std = []
 
 [dependencies]
 heapless = { workspace = true }

--- a/edge-dhcp/Cargo.toml
+++ b/edge-dhcp/Cargo.toml
@@ -17,14 +17,15 @@ categories = [
 [features]
 default = ["io"]
 std = ["io"]
-io = ["embassy-futures", "edge-nal"]
+io = ["embassy-futures", "edge-nal", "time"]
+time = ["embassy-time"]
 
 [dependencies]
 heapless = { workspace = true }
 log = { workspace = true }
 rand_core = "0.6"
 embassy-futures = { workspace = true, optional = true }
-embassy-time = { workspace = true, default-features = false } # TODO: Make optional
+embassy-time = { workspace = true, optional = true, default-features = false }
 edge-nal = { workspace = true, optional = true }
 num_enum = { version = "0.7", default-features = false }
 edge-raw = { workspace = true, default-features = false }

--- a/edge-dhcp/src/lib.rs
+++ b/edge-dhcp/src/lib.rs
@@ -12,6 +12,7 @@ use num_enum::TryFromPrimitive;
 use edge_raw::bytes::{self, BytesIn, BytesOut};
 
 pub mod client;
+#[cfg(feature = "time")]
 pub mod server;
 
 #[cfg(feature = "io")]


### PR DESCRIPTION
Hi, I appreciate the effort invested in the creation of edge-net crates, they been a great help with no_std.
That said I had some issues with forced embassy dependencies for targets that are not reliant on embassy,
And since I've seen that edge-dhcp had a TODO for this, I'll PR the "solution" I use.
Its just a feature gate for edge-dhcp::server module, separate from io in case someone wants to use it manually.