### PR TITLE
fix: allow all frame types except 'reserved' to include payload

### DIFF
--- a/edge-ws/src/lib.rs
+++ b/edge-ws/src/lib.rs
@@ -193,12 +193,7 @@ impl FrameHeader {
 
             let frame_header = FrameHeader {
                 frame_type,
-                payload_len: matches!(
-                    frame_type,
-                    FrameType::Binary(_) | FrameType::Text(_) | FrameType::Continue(_)
-                )
-                .then(|| payload_len)
-                .unwrap_or(0),
+                payload_len,
                 mask_key,
             };
 


### PR DESCRIPTION
All frame types except the 'reserved' opcodes should support payload, and therefore payload_len should not be zero.
Currently for Ping/Pong/Close payload_len is set to zero even if provided by the other party.
In each of them this is required and even useful.
- Ping - useful to measure for example roudtrip time, 
- Close - provide reason for close.
- Pong - must return the payload sent by the ping.

I fixed for the client, since that's what I'm using.
I don't know if the same code is used by the server side.
