### PR TITLE
Respect payload length of ws control messages

### DIFF
--- a/edge-ws/CHANGELOG.md
+++ b/edge-ws/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Respect payload length of control messages
 
 ## [0.4.0] - 2025-01-02
 * Option to erase the generics from the IO errors

--- a/edge-ws/src/lib.rs
+++ b/edge-ws/src/lib.rs
@@ -193,12 +193,7 @@ impl FrameHeader {
 
             let frame_header = FrameHeader {
                 frame_type,
-                payload_len: matches!(
-                    frame_type,
-                    FrameType::Binary(_) | FrameType::Text(_) | FrameType::Continue(_)
-                )
-                .then(|| payload_len)
-                .unwrap_or(0),
+                payload_len,
                 mask_key,
             };
 


### PR DESCRIPTION
Websocket control messages are allowed to have payloads. Don't set the payload length to zero when deserializing them, which can corrupt the message and potentially the remainder of the stream.